### PR TITLE
Fix an issue within this nif when the package is compiled with C23+

### DIFF
--- a/c_src/csv_parser_nif.c
+++ b/c_src/csv_parser_nif.c
@@ -7,9 +7,15 @@
 #define OPTION_DELIM_TABS 1
 #define OPTION_RETURN_BINARY 2
 
+#if __STDC_VERSION__ >= 202311L
+// C23 and later
+#include <stdbool.h>
+#else
+// Pre-C23
 typedef int bool;
 #define true 1
 #define false 0
+#endif
 
 #define MAX_PARSE_SIZE 128
 // Empty lines are filtered out by libcsv (default behaviour). Each


### PR DESCRIPTION
I'm getting this issue when running `ecsv` in [one of my projects](https://github.com/Dr-Nekoma/lyceum/actions/runs/20767074457/job/59635433481#step:8:498), it happens when I try to use it in a newer version of `rebar3` and OTP 28+, this is just a small patch so I can keep using this lib, while keep backwards compatible behavior everywhere else.

```
===> /home/leto/Code/Personal/lyceum/server/c_src/csv_parser_nif.c:10:13: error: ‘bool’ cannot be defined via ‘typedef’
   10 | typedef int bool;
      |             ^~~~
/home/leto/Code/Personal/lyceum/server/c_src/csv_parser_nif.c:10:13: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
/home/leto/Code/Personal/lyceum/server/c_src/csv_parser_nif.c:10:1: warning: useless type name in empty declaration
   10 | typedef int bool;
      | ^~~~~~~
```

@martin-torhage 

